### PR TITLE
Add git ignore for MacOSX and Ruby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,67 @@
 /.env
 /build
 /misc
+
+### https://raw.github.com/github/gitignore/8ab86f6bb71e85b5046f1d921bbbe5ceec9063ba/Ruby.gitignore
+
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/test/tmp/
+/test/version_tmp/
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalisation:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+.ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+
+### https://raw.github.com/github/gitignore/8ab86f6bb71e85b5046f1d921bbbe5ceec9063ba/Global/OSX.gitignore
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk


### PR DESCRIPTION
rbenv 環境をベースに開発している場合に `.ruby-version` という使用する ruby バージョンを示したファイルが生成されるのですが、それが `.gitignore` に入っていなかったため、gitignore の整理を行いました。

今回は [gibo](https://github.com/simonwhitaker/gibo) を使用して、 MacOSX 環境、 Ruby 環境において、gitignore によく加えられているものをテンプレートとして出力してくれるツールを使用しています。

もしよろしければ、ご確認をお願いします。
（無用なPullRequest であれば close してしまってください :bow: ）